### PR TITLE
Fix init file, so users can import everything as expected

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,1 @@
+from apm import *


### PR DESCRIPTION
The common usage for importing from the file is to do:

```python
    >> from apm import *
```

Which works fine when you have the `apm.py` file in the
current directory. This init file allows you to use the
exact same code (`from apm import *`) and end up with
the same result using the pip-installed version.